### PR TITLE
Fix regexp strings

### DIFF
--- a/mansnip
+++ b/mansnip
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import sys, re, os, logging, pdb
 
 # less and others have a number of things like this 

--- a/mansnip
+++ b/mansnip
@@ -67,14 +67,14 @@ def matcher(term):
                 # ffmpeg uses [ at times (see hwaccel), many things use ',' to show a second option.
                 # mmcli uses = a lot of the times
                 r'([\s_\[=].*|, .*|)',
-            '|',
+            r'|',
                 # this is for the long options, sometimes (git config) specified by commas
                 #'-.*\s({})',
                 r'-.*({})',
 
                 # and kinda our same capture from above
                 r'([\s_\[=].*|)',
-         ')$'
+         r')$'
        ]).format(term, term)
 
 # the thing we are genuinely looking for

--- a/mansnip
+++ b/mansnip
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
 import sys, re, os, logging, pdb
 
 # less and others have a number of things like this 
@@ -56,24 +56,24 @@ opts = '|'.join(pack)
 
 def matcher(term):
     return ''.join([
-        '^\s*',
-        '(',
+        r'^\s*',
+        r'(',
                  # lsof uses +|- syntax,
-                '(\+\||)',
+                r'(\+\||)',
 
                 # the term itself
-                '({})',
+                r'({})',
 
                 # ffmpeg uses [ at times (see hwaccel), many things use ',' to show a second option.
                 # mmcli uses = a lot of the times
-                '([\s_\[=].*|, .*|)',
+                r'([\s_\[=].*|, .*|)',
             '|',
                 # this is for the long options, sometimes (git config) specified by commas
                 #'-.*\s({})',
-                '-.*({})',
+                r'-.*({})',
 
                 # and kinda our same capture from above
-                '([\s_\[=].*|)',
+                r'([\s_\[=].*|)',
          ')$'
        ]).format(term, term)
 
@@ -81,7 +81,7 @@ def matcher(term):
 my_re = matcher(opts)
 
 # a general purpose getopts re
-getopts_simple_re = '^\s+(-{1,2}\w+\s?\w*)+\s*$'
+getopts_simple_re = r'^\s+(-{1,2}\w+\s?\w*)+\s*$'
 
 logging.info("The re for this search: {}".format(my_re))
 
@@ -109,7 +109,7 @@ last_stack_guess = []
 # Words we can just leave out of the breadcrumb.
 filler_terms = ['DESCRIPTION','OPTIONS']
 
-clean_ansi = lambda w: re.sub('(.\x08|\x1B\[\d*m)', '', w)
+clean_ansi = lambda w: re.sub(r'(.\x08|\x1B\[\d*m)', '', w)
 
 #
 # There's lots of let's say "creative" ways to format man pages, so
@@ -145,7 +145,7 @@ while line_num + 1 < len(man_input):
     # Establish the "indent", this is crucial to how essentially 
     # everything works.
     #
-    indent = re.match('^(\s*)', line).end()
+    indent = re.match(r'^(\s*)', line).end()
     indent_window = indent_window[-2:] + [indent]
 
     if len(line):
@@ -321,7 +321,7 @@ while line_num + 1 < len(man_input):
                     stack_print += "\n"
                 else:
                     stack_print = ''
-                    buf[0] = re.sub('^\s{%d}' % rs, '', buf[0])
+                    buf[0] = re.sub(r'^\s{%d}' % rs, '', buf[0])
 
                 # This makes the tests more portable
                 if not show_line_numbers:


### PR DESCRIPTION
improperly quoted regex pattern strings induce warnings when run:

```
mansnip:59: SyntaxWarning: invalid escape sequence '\s'
  '^\s*',
mansnip:62: SyntaxWarning: invalid escape sequence '\+'
  '(\+\||)',
mansnip:69: SyntaxWarning: invalid escape sequence '\s'
  '([\s_\[=].*|, .*|)',
mansnip:76: SyntaxWarning: invalid escape sequence '\s'
  '([\s_\[=].*|)',
mansnip:84: SyntaxWarning: invalid escape sequence '\s'
  getopts_simple_re = '^\s+(-{1,2}\w+\s?\w*)+\s*$'
mansnip:112: SyntaxWarning: invalid escape sequence '\['
  clean_ansi = lambda w: re.sub('(.\x08|\x1B\[\d*m)', '', w)
mansnip:148: SyntaxWarning: invalid escape sequence '\s'
  indent = re.match('^(\s*)', line).end()
mansnip:324: SyntaxWarning: invalid escape sequence '\s'
  buf[0] = re.sub('^\s{%d}' % rs, '', buf[0])
```

(tested with python 3.12)